### PR TITLE
Updated link to file publisher binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Create a task manifest file (exemplary file in [examples/tasks/] (examples/tasks
 
 Get mock file plugin for publishing, appropriate for Linux or Darwin:
 ```
-wget  http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/latest/linux/x86_64/snap-plugin-publisher-file
+wget  http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/latest_build/linux/x86_64/snap-plugin-publisher-file
 ```
 or 
 ```
-wget  http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/latest/darwin/x86_64/snap-plugin-publisher-file
+wget  http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/latest_build/darwin/x86_64/snap-plugin-publisher-file
 ```
 
 Load mock file plugin for publishing:


### PR DESCRIPTION
Update link to file publisher binary 

Summary of changes:
- before:  
http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/latest/darwin/x86_64/snap-plugin-publisher-file (deprecated)
- after:  
http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/latest_build/darwin/x86_64/snap-plugin-publisher-file

Testing done:
- updated links work properly (binary is available and download in the right way)
